### PR TITLE
Use https to fetch submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdParty/SortFilterProxyModel"]
 	path = 3rdParty/SortFilterProxyModel
-	url = git@github.com:oKcerG/SortFilterProxyModel.git
+	url = https://github.com/oKcerG/SortFilterProxyModel.git


### PR DESCRIPTION
Openembedded warns:

| WARNING: sortfilterproxymodelcmake-0.0.2+gitAUTOINC+6b925b435c-r0 do_fetch: Submodule included by gitsm://github.com/ZeraGmbH/SortFilterProxyModelCmake.git refers to relative ssh reference git@github.com:oKcerG/SortFilterProxyModel.git. References may fail if not absolute.

This is correct: Users without account or ssh-key won't be able to download submodule

Closes [1]

[1] https://github.com/ZeraGmbH/SortFilterProxyModelCmake/issues/1

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>